### PR TITLE
Update PegasusPlugin to remove stale schema files when preparing schemas for publication

### DIFF
--- a/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
+++ b/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginCacheabilityTest.groovy
@@ -1,0 +1,42 @@
+package com.linkedin.pegasus.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.*;
+
+class PegasusPluginCacheabilityTest extends Specification {
+  @Rule
+  TemporaryFolder tempDir = new TemporaryFolder()
+
+  def 'mainCopySchemas tasks are up-to-date'() {
+    setup:
+    def buildFile = tempDir.newFile('build.gradle')
+    buildFile.text = "plugins { id 'pegasus' }"
+    def pegasusDir = tempDir.newFolder('src', 'main', 'pegasus')
+    new File("$pegasusDir.path$File.separator"+"A.pdsc").createNewFile()
+
+    when:
+    def runner = GradleRunner.create()
+        .withProjectDir(tempDir.root)
+        .withPluginClasspath()
+        .withArguments("mainCopySchemas")
+        .forwardOutput()
+    def result = runner.build()
+
+    then:
+    result.task(':mainDestroyStaleFiles').outcome == SKIPPED
+    result.task(':mainCopyPdscSchemas').outcome == SKIPPED
+    result.task(':mainCopySchemas').outcome == SUCCESS
+
+    when:
+    result = runner.build()
+
+    then:
+    result.task(':mainDestroyStaleFiles').outcome == SKIPPED
+    result.task(':mainCopyPdscSchemas').outcome == SKIPPED
+    result.task(':mainCopySchemas').outcome == UP_TO_DATE
+  }
+}

--- a/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginIntegrationTest.groovy
+++ b/gradle-plugins/src/integTest/groovy/com/linkedin/pegasus/gradle/PegasusPluginIntegrationTest.groovy
@@ -1,10 +1,11 @@
 package com.linkedin.pegasus.gradle
 
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class PegasusPluginIntegrationTest extends Specification {
   @Rule
@@ -24,6 +25,42 @@ class PegasusPluginIntegrationTest extends Specification {
         .build()
 
     then:
-    result.task(':mainDataTemplateJar').outcome == TaskOutcome.SUCCESS
+    result.task(':mainDataTemplateJar').outcome == SUCCESS
+  }
+
+  def 'mainCopySchema will remove stale pdsc'() {
+    setup:
+    def buildFile = tempDir.newFile('build.gradle')
+    buildFile.text = "plugins { id 'pegasus' }"
+    def schemasDir = tempDir.newFolder('src', 'main', 'pegasus')
+    def mainSchemasDir = tempDir.newFolder('build', 'mainSchemas')
+    def pdscFilename1 = "A.pdsc"
+    def pdscFilename2 = "B.pdsc"
+    def pdscFile1 = new File("$schemasDir.path$File.separator$pdscFilename1")
+    pdscFile1.createNewFile()
+    def pdscFile2 = new File("$schemasDir.path$File.separator$pdscFilename2")
+    pdscFile2.createNewFile()
+    GradleRunner runner = GradleRunner.create()
+        .withProjectDir(tempDir.root)
+        .withArguments("mainCopySchemas")
+        .withPluginClasspath()
+        .forwardOutput()
+
+    when:
+    def result = runner.build()
+
+    then:
+    result.task(':mainCopySchemas').getOutcome() == SUCCESS
+    new File("$mainSchemasDir$File.separator$pdscFilename1").exists()
+    new File("$mainSchemasDir$File.separator$pdscFilename2").exists()
+
+    when:
+    pdscFile1.delete()
+    result = runner.build()
+
+    then:
+    result.task(':mainCopySchemas').getOutcome() == SUCCESS
+    !new File("$mainSchemasDir$File.separator$pdscFilename1").exists()
+    new File("$mainSchemasDir$File.separator$pdscFilename2").exists()
   }
 }

--- a/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
+++ b/gradle-plugins/src/main/java/com/linkedin/pegasus/gradle/PegasusPlugin.java
@@ -57,9 +57,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.Copy;
-import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.*;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
@@ -1631,26 +1629,28 @@ public class PegasusPlugin implements Plugin<Project>
     Task compileTask = project.getTasks().getByName(targetSourceSet.getCompileJavaTaskName());
     compileTask.dependsOn(generateDataTemplatesTask);
 
-    // we need to delete the build directory before staging files for translation/code generation, in case there were
-    // left over files from a previous execution. This is not a problem if the input for translation/code generation
-    // hasn't changed at all, because gradle will just realize the buildDir can be rebuilt from cache.
-    Task destroyStaleFiles = project.getTasks().create(sourceSet.getName() + "DestroyStaleFiles");
-    if (isPropertyTrue(project, DESTROY_STALE_FILES_ENABLE) && publishableSchemasBuildDir.exists())
-    {
-      destroyStaleFiles.getInputs().dir(publishableSchemasBuildDir);
-      destroyStaleFiles.doLast(new CacheableAction<>(task -> project.delete(publishableSchemasBuildDir)));
-    }
+    // Dummy task to maintain backward compatibility
+    // TODO: Delete this task once use cases have had time to reference the new task
+    Task destroyStaleFiles = project.getTasks().create(sourceSet.getName() + "DestroyStaleFiles", Delete.class);
+    destroyStaleFiles.onlyIf(task -> {
+      project.getLogger().lifecycle("{} task is a NO-OP task.", task.getPath());
+      return false;
+    });
 
     // Dummy task to maintain backward compatibility, as this task was replaced by CopySchemas
     // TODO: Delete this task once use cases have had time to reference the new task
-    Task copyPdscSchemasTask = project.getTasks().create(sourceSet.getName() + "CopyPdscSchemas");
+    Task copyPdscSchemasTask = project.getTasks().create(sourceSet.getName() + "CopyPdscSchemas", Copy.class);
     copyPdscSchemasTask.dependsOn(destroyStaleFiles);
+    copyPdscSchemasTask.onlyIf(task -> {
+      project.getLogger().lifecycle("{} task is a NO-OP task.", task.getPath());
+      return false;
+    });
 
-    // Copy all schema files directly over for publication
+    // Prepare schema files for publication by syncing schema folders.
     Task prepareSchemasForPublishTask = project.getTasks()
-        .create(sourceSet.getName() + "CopySchemas", Copy.class, task ->
+        .create(sourceSet.getName() + "CopySchemas", Sync.class, task ->
         {
-          task.from(dataSchemaDir, copySpec -> DATA_TEMPLATE_FILE_SUFFIXES.forEach(suffix -> copySpec.include("**/*" + suffix)));
+          task.from(dataSchemaDir, syncSpec -> DATA_TEMPLATE_FILE_SUFFIXES.forEach(suffix -> syncSpec.include("**/*" + suffix)));
           task.into(publishableSchemasBuildDir);
         });
     prepareSchemasForPublishTask.dependsOn(copyPdscSchemasTask);

--- a/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/TestPegasusPlugin.java
+++ b/gradle-plugins/src/test/java/com/linkedin/pegasus/gradle/TestPegasusPlugin.java
@@ -15,12 +15,17 @@
 */
 package com.linkedin.pegasus.gradle;
 
-import java.util.Map;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.Delete;
+import org.gradle.api.tasks.Sync;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.testng.annotations.Test;
+
+import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -55,5 +60,17 @@ public final class TestPegasusPlugin
 
     assertFalse(pegasusOptions.get("main").hasGenerationMode(PegasusOptions.GenerationMode.AVRO));
     assertTrue(pegasusOptions.get("main").hasGenerationMode(PegasusOptions.GenerationMode.PEGASUS));
+  }
+
+  @Test
+  public void testPluginCreatesCorrectTasks() {
+    // Given/When: Pegasus Plugin is applied to a project.
+    Project project = ProjectBuilder.builder().build();
+    project.getPlugins().apply(PegasusPlugin.class);
+
+    // Then: Validate the Copy/Sync Schema tasks are of the correct type.
+    assertTrue(project.getTasks().getByName("mainDestroyStaleFiles") instanceof Delete);
+    assertTrue(project.getTasks().getByName("mainCopyPdscSchemas") instanceof Copy);
+    assertTrue(project.getTasks().getByName("mainCopySchemas") instanceof Sync);
   }
 }


### PR DESCRIPTION
There was a bug where stale schema files were being packaged into the
data-template jars. There is a flag that allows us to delete the stale
files but this caused a different problem where the tasks would never be
up to date, which would cause other issues if we were running a server
in a hot reload mode.

The fix is to use a sync task instead of a delete and copy tasks.

* Fix PegasusPlugin to use the sync task when moving the files to the
build/mainSchemas for data template preparation
* Create test to validate stale files are deleted
* Create test to validate mainCopySchema task will be up to date when no
changes happen